### PR TITLE
Using system dialog for saving invoices on desktop

### DIFF
--- a/lib/src/domain/usecases/generate_invoice.dart
+++ b/lib/src/domain/usecases/generate_invoice.dart
@@ -9,7 +9,7 @@ import 'package:pdf/widgets.dart';
 abstract class IGenerateInvoiceUseCase {
   Document createPdf(Invoice invoice);
 
-  Future<File> savePdf(Invoice invoice, Document pdf);
+  Future<File> savePdf(Invoice invoice, Document pdf, String? path);
 }
 
 @Injectable(as: IGenerateInvoiceUseCase)
@@ -24,9 +24,9 @@ class GenerateInvoiceUseCase implements IGenerateInvoiceUseCase {
   }
 
   @override
-  Future<File> savePdf(Invoice invoice, Document pdf) async {
+  Future<File> savePdf(Invoice invoice, Document pdf, String? path) async {
     final Directory appDocumentsDir = await getApplicationDocumentsDirectory();
-    final file = File("${appDocumentsDir.path}/invoice_${invoice.id}.pdf");
+    final file = File(path ?? "${appDocumentsDir.path}/invoice_${invoice.id}.pdf");
     return file.writeAsBytes(await pdf.save());
   }
 }

--- a/lib/src/presentation/utils/share_invoice.dart
+++ b/lib/src/presentation/utils/share_invoice.dart
@@ -4,6 +4,8 @@ import 'package:ambush_app/src/domain/usecases/generate_invoice.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:universal_html/html.dart' as web_file;
+import 'dart:io' show Platform;
+import 'package:file_picker/file_picker.dart';
 
 abstract class IShareInvoice {
   Future<void> share(Invoice invoice);
@@ -25,8 +27,17 @@ class ShareInvoice implements IShareInvoice {
       web_file.AnchorElement(
         href: web_file.Url.createObjectUrlFromBlob(blob).toString(),
       )..setAttribute("download", "invoice.pdf")..click();
+    } else if(Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+      final filePath = await FilePicker.platform.saveFile(
+        dialogTitle: "Save invoice",
+        allowedExtensions: ['pdf'],
+        fileName: "invoice_${invoice.id}.pdf",
+      );
+      if (filePath != null) {
+        final _ = await _generateInvoiceUseCase.savePdf(invoice, pdf, filePath);
+      }
     } else {
-      final file = await _generateInvoiceUseCase.savePdf(invoice, pdf);
+      final file = await _generateInvoiceUseCase.savePdf(invoice, pdf, null);
       await Share.shareXFiles([XFile(file.path)]);
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "903dd4ba13eae7cef64acc480e91bf54c3ddd23b5b90b639c170f3911e489620"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -302,6 +310,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.6+5"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.17"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -959,4 +975,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.7.0-0"
+  flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   flutter_svg_provider: ^1.0.6
   universal_html: ^2.2.4
   material_color_utilities: ^0.5.0
+  file_picker: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Summary

Invoice sharing on Mac would open a "sharing" dialog. This is undesirable as this dialog doesn't allow for saving the file locally (as it does on Mobile).

# Changes

* Added the [file_picker](https://pub.dev/packages/file_picker) package dependency
* Added a condition to the `ShareInvoice.share` method to catch all desktop share attempts
* Changed the `IGenerateInvoiceUseCase.savePdf` method to accept an optional file path to save the invoice

