### PR TITLE
APP-44: [macOS] can't share invoice

### DIFF
--- a/lib/src/presentation/utils/share_invoice.dart
+++ b/lib/src/presentation/utils/share_invoice.dart
@@ -22,14 +22,17 @@ class ShareInvoice implements IShareInvoice {
     var pdf = _generateInvoiceUseCase.createPdf(invoice);
 
     if (kIsWeb) {
-      final bytes = await pdf.save() ;
+      final bytes = await pdf.save();
       var blob = web_file.Blob([bytes], 'application/pdf', 'native');
       web_file.AnchorElement(
         href: web_file.Url.createObjectUrlFromBlob(blob).toString(),
-      )..setAttribute("download", "invoice_${invoice.id}.pdf")..click();
-    } else if(Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+      )
+        ..setAttribute("download", "invoice_${invoice.id}.pdf")
+        ..click();
+    } else if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
       final filePath = await FilePicker.platform.saveFile(
         dialogTitle: "Save invoice",
+        type: FileType.custom,
         allowedExtensions: ['pdf'],
         fileName: "invoice_${invoice.id}.pdf",
       );


### PR DESCRIPTION
According to the Flutter File Picker API documentation, we should set the FileType to FileType.custom if we are providing allowedExtensions:

[NOTE: You must use FileType.custom when providing allowedExtensions, else it will throw an exception.](https://github.com/miguelpruivo/flutter_file_picker/wiki/API)


Mac OS App:

https://github.com/user-attachments/assets/299cf75a-2a1f-442e-b2ed-81096b5fb051

Chrome web app:


https://github.com/user-attachments/assets/e46841c3-a929-436d-bec2-42b5bf281d8f


