### PR TITLE
Invalid Invoice ID is not handled

### DIFF
--- a/lib/src/core/settings/const.dart
+++ b/lib/src/core/settings/const.dart
@@ -7,3 +7,6 @@ const double extraLargeMargin = 64;
 const double defaultPageMaxWidth = 396.0;
 
 const formatErrorMessage = 'There was an error formatting your backup.';
+const requiredField = "Required field";
+const invalidValue = "Invalid value";
+const invalidEmail = "Invalid e-mail";

--- a/lib/src/core/utils/field_validators.dart
+++ b/lib/src/core/utils/field_validators.dart
@@ -1,17 +1,19 @@
+import 'package:ambush_app/src/core/settings/const.dart';
+
 String? requiredFieldValidator(String? value) {
-  if(value == null || value.isEmpty) {
-    return "Required filed";
+  if (value == null || value.isEmpty) {
+    return requiredField;
   }
   return null;
 }
 
 String? doubleValueValidator(String? value) {
   if (value == null || value.isEmpty) {
-    return "Required filed";
+    return requiredField;
   }
 
   if (double.tryParse(value) == null) {
-    return "Invalid value";
+    return invalidValue;
   }
 
   return null;
@@ -19,11 +21,23 @@ String? doubleValueValidator(String? value) {
 
 String? requiredEmailValidator(String? value) {
   if (value == null || value.isEmpty) {
-    return "Required filed";
+    return requiredField;
   }
 
   if (!value.contains("@")) {
-    return "Invalid email";
+    return invalidEmail;
+  }
+
+  return null;
+}
+
+String? intValueValidator(String? value) {
+  if (value == null || value.isEmpty) {
+    return requiredField;
+  }
+
+  if (int.tryParse(value) == null) {
+    return invalidValue;
   }
 
   return null;

--- a/lib/src/presentation/add_invoice/add_invoice_page.dart
+++ b/lib/src/presentation/add_invoice/add_invoice_page.dart
@@ -35,12 +35,12 @@ class AddInvoicePage extends StatelessWidget {
           children: [
             InputField(
               label: "Invoice Id",
-              helperText: "Enter the a unique invoice Id",
+              helperText: "Enter a numeric unique invoice Id",
               textInputAction: TextInputAction.next,
               keyboardType: TextInputType.number,
               controller: _viewModel.idController,
               autovalidateMode: AutovalidateMode.onUserInteraction,
-              validator: requiredFieldValidator,
+              validator: intValueValidator,
             ),
             const SizedBox(height: marginBetweenFields),
             InputField(


### PR DESCRIPTION
Currently the app doesn't provide any error handling regarding invoice ID format issues. When we insert an invalid character, it doesn't show any message and clicking Save button doesn't work, which causes a bad experience. This PR adds an extra validator for invoice ID field.

Closes issue #90 

# Evidence(macOS)

https://github.com/user-attachments/assets/21aa5e99-0bf7-47fc-a74b-cc2405d532fb

