### PR TITLE
refactor: replace `removeTrailingZeros` utility with direct `toString AsFixed` formatting for quantity.

### DIFF
--- a/lib/src/domain/models/service_info.dart
+++ b/lib/src/domain/models/service_info.dart
@@ -1,8 +1,6 @@
 import 'package:ambush_app/src/domain/models/currency.dart';
 import 'package:extended_masked_text/extended_masked_text.dart';
 
-import '../../presentation/utils/remove_trailing_zeros.dart';
-
 class ServiceInfo {
   final String description;
   final double quantity;
@@ -20,7 +18,9 @@ class ServiceInfo {
   }
 
   String formattedQuantity() {
-    return removeTrailingZeros(quantity.toString());
+    final hasDecimal = quantity % 10 != 0;
+    final fixed = hasDecimal ? 2 : 0;
+    return quantity.toStringAsFixed(fixed);
   }
 
   //ignore: strict_top_level_inference


### PR DESCRIPTION
This pull request simplifies the way quantities are formatted in the `ServiceInfo` model by removing a utility import and updating the `formattedQuantity` method for clarity and efficiency.

Formatting logic update:

* The `formattedQuantity` method in the `ServiceInfo` class now directly formats the `quantity` value using `toStringAsFixed`, displaying two decimal places only when necessary, instead of relying on the external `removeTrailingZeros` utility.

Code cleanup:

* Removed the unused import of `remove_trailing_zeros.dart` from the `service_info.dart` file.